### PR TITLE
Update server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@
 
 1. `npm install rdme --save-dev`
 2. `npx rdme openapi openapi/openapi.yml`
+
+Note: This repo should remain public as long as its referenced by other OpenAPI files.

--- a/token-auth.yml
+++ b/token-auth.yml
@@ -7,8 +7,6 @@ info:
   version: '1.0'
 
 servers:
-  - url: https://api.getmentum.com/v0
-    description: Production endpoint.
   - url: https://sandbox.getmentum.com/v0
     description: Sandbox environment.
 


### PR DESCRIPTION
## Problem

* `api.getmentum.com` is not live and is in the docs

## Solution

* remove unused URL

## Testing Done

Note: merging publishes immediately, so a preview is recommended.

- [x] Previewed changes in staging [mentum-stag.readme.io](https://mentum-stag.readme.io)
