### PR TITLE
Minor: Token Auth Revisions

### DIFF
--- a/token-auth.yml
+++ b/token-auth.yml
@@ -85,8 +85,8 @@ paths:
           - JWT_Authentication: []
         tags:
           - Token Authentication
-        summary: Log out an Access Token
-        description: Log out an Access Token
+        summary: Log out a Token
+        description: Use this endpoint to log out an access token, refresh token, or both.
         requestBody:
           content:
             application/json:
@@ -130,9 +130,6 @@ paths:
               schema: 
                 type: object
                 properties:
-                  access:
-                    description: JWT Access Token
-                    type: string
                   refresh:
                     description: JWT Refresh Token
                     type: string


### PR DESCRIPTION
## Problem
1. The logout docs for the token are called `Logout an Access Token` → should be `Logout a Token` as it supports both access and/or refresh tokens.
2. The access token is not required in the `refresh` token endpoint request body to get a new pair.

## Solution

Update the docs accordingly. 

## Testing Done

Note: merging publishes immediately, so a preview is recommended.

- [x] Previewed changes in staging [mentum-stag.readme.io](https://mentum-stag.readme.io)
